### PR TITLE
LOG-123 added an error code along with uauth custom errors

### DIFF
--- a/packages/js/src/errors/createError.ts
+++ b/packages/js/src/errors/createError.ts
@@ -1,6 +1,10 @@
-export default function createError(name: string, message: string) {
+export default function createError(
+  errorName: string,
+  message: string,
+  errorCode = 'E1000',
+) {
   return class extends Error {
-    name = name
+    name = `${errorCode} ${errorName}`
     constructor() {
       super(message)
     }

--- a/packages/js/src/errors/errors.ts
+++ b/packages/js/src/errors/errors.ts
@@ -1,11 +1,17 @@
 import createError from './createError'
 
+// Uauth specific errors
+// Error code E1000 will be assigned for generic or unspecified errors,
+// TBD, public facing wiki/docs page with list of error codes,
+
 export const PopupTimeoutError = createError(
   'PopupTimeoutError',
   'The popup has timed out.',
+  'E1001',
 )
 
 export const PopupClosedError = createError(
   'PopupClosedError',
   'The popup was closed.',
+  'E1002',
 )


### PR DESCRIPTION
-Assigned our custom errors an error code
-Error code is displayed to the end user when thrown
-If no error code is assigned during "createError", a default of "E1000" is used
-TBD, add the list of error codes on documentation pages/ external wiki, where we can update in the future with more.

