### PR TITLE
[LOG-125] Add optional types

### DIFF
--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -91,6 +91,8 @@ export interface UserInfo
     Partial<PhoneClaims>,
     Partial<ProfileClaims> {
   sub: string
+  eip4361_message?: string
+  eip4361_signature?: string
 }
 
 export interface JWTClaims {

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -51,6 +51,8 @@ export type WalletType = 'web3' | 'walletconnect'
 export interface WalletClaims {
   wallet_address: string
   wallet_type_hint: WalletType
+  eip4361_message?: string
+  eip4361_signature?: string
 }
 
 export interface EmailClaims {
@@ -91,8 +93,6 @@ export interface UserInfo
     Partial<PhoneClaims>,
     Partial<ProfileClaims> {
   sub: string
-  eip4361_message?: string
-  eip4361_signature?: string
 }
 
 export interface JWTClaims {


### PR DESCRIPTION
[[LOG-125](https://linear.app/unstoppable-domains/issue/LOG-125/bug-eip4361-not-defined-error-message)] Resolve the `eip4361_message` and `eip4361_signature`  are not defined on type `UserInfo` errors.
