### PR TITLE
[LOG-253] Attach UAuth Version to Window

### DIFF
--- a/.github/workflows/build_test_release.yml
+++ b/.github/workflows/build_test_release.yml
@@ -218,6 +218,7 @@ jobs:
 
       - name: Publish to NPM
         run: |-
+          yarn build
           variable=${{ steps.get_workspaces.outputs.result }}
           for workspace in ${variable//,/ }
           do
@@ -225,4 +226,4 @@ jobs:
           done
 
       - name: Push
-        run: git push --atomic origin main "v${{ steps.evaluate_bump.outputs.new_version }}"
+        run: git push --atomic origin ${{ github.ref_name }} "v${{ steps.evaluate_bump.outputs.new_version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-**/src/version.ts
+packages/*/src/version.ts

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+**/src/version.ts

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "foreach": "yarn workspaces foreach --verbose --no-private --topological-dev",
     "format": "prettier -w .",
     "husky": "[ -z \"${CI:-}\" ] && husky install",
-    "lint": "eslint --fix .",
+    "lint": "yarn foreach run export-version; eslint --fix .",
     "precommit": "lint-staged",
     "prepush": "exit",
-    "test": "jest",
+    "test": "yarn foreach run export-version; jest",
     "typecheck": "yarn foreach run typecheck"
   },
   "devDependencies": {

--- a/packages/bnc-onboard/package.json
+++ b/packages/bnc-onboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/bnc-onboard",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -34,5 +34,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthBncOnboard"
+  "amdName": "UAuthBncOnboard",
+  "stableVersion": "2.0.0"
 }

--- a/packages/bnc-onboard/package.json
+++ b/packages/bnc-onboard/package.json
@@ -14,9 +14,10 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
-    "release": "../../scripts/release.sh"
+    "build": "yarn export-version; microbundle",
+    "dev": "yarn export-version; microbundle watch",
+    "release": "../../scripts/release.sh",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "dependencies": {
     "@uauth/js": "workspace:*",

--- a/packages/bnc-onboard/src/index.ts
+++ b/packages/bnc-onboard/src/index.ts
@@ -6,6 +6,11 @@ import type {
 } from '@uauth/js'
 import type {IWalletConnectProviderOptions} from '@walletconnect/types'
 import type {API, WalletModule} from 'bnc-onboard/dist/src/interfaces'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.BNC_ONBOARD = VERSION
 
 export interface ConstructorOptions extends Partial<UAuthConstructorOptions> {
   uauth?: UAuth

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/common",
-  "version": "2.0.1",
+  "version": "2.0.1-rc.1",
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -30,5 +30,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthCommon"
+  "amdName": "UAuthCommon",
+  "stableVersion": "2.0.1"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,9 +16,10 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
-    "release": "../../scripts/release.sh"
+    "build": "yarn export-version; microbundle",
+    "dev": "yarn export-version; microbundle watch",
+    "release": "../../scripts/release.sh",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "devDependencies": {
     "@unstoppabledomains/resolution": "^7.0"

--- a/packages/common/src/DefaultWebFingerResolver.ts
+++ b/packages/common/src/DefaultWebFingerResolver.ts
@@ -1,5 +1,10 @@
 import {isJRD} from './JRD'
 import {JRDDocument, WebFingerRecord, WebFingerResolverOptions} from './types'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.COMMON = VERSION
 
 export default class DefaultWebFingerResolver {
   constructor(public options: WebFingerResolverOptions) {}

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -16,8 +16,9 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
+    "build": "yarn export-version; microbundle",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts",
+    "dev": "yarn export-version; microbundle watch",
     "test": "exit; jest --watch",
     "test-ci": "jest --ci",
     "typecheck": "tsc --noEmit"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/js",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -36,5 +36,6 @@
     "access": "public",
     "registry": "https://registry.npmjs.org"
   },
-  "amdName": "UAuth"
+  "amdName": "UAuth",
+  "stableVersion": "2.0.0"
 }

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -40,6 +40,11 @@ import {
   UserOptions,
 } from './types'
 import * as util from './util'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.JS = VERSION
 
 export default class Client {
   util = util

--- a/packages/moralis/package.json
+++ b/packages/moralis/package.json
@@ -16,9 +16,10 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle --jsx 'React.createElement'",
-    "dev": "microbundle watch --jsx 'React.createElement'",
-    "release": "../../scripts/release.sh"
+    "build": "yarn export-version; microbundle --jsx 'React.createElement'",
+    "dev": "yarn export-version; microbundle watch --jsx 'React.createElement'",
+    "release": "../../scripts/release.sh",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "dependencies": {
     "@uauth/js": "workspace:*"

--- a/packages/moralis/package.json
+++ b/packages/moralis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/moralis",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "type": "commonjs",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -38,5 +38,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthMoralis"
+  "amdName": "UAuthMoralis",
+  "stableVersion": "2.0.0"
 }

--- a/packages/moralis/src/UAuthMoralisConnector.ts
+++ b/packages/moralis/src/UAuthMoralisConnector.ts
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type UAuth from '@uauth/js'
 import type {UAuthConstructorOptions, UserInfo} from '@uauth/js'
-
 import AbstractWeb3Connector from './AbstractWeb3Connector'
 
 import {getMoralisRpcs} from './MoralisRpcs'
 import verifyChainId from './Utils'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.MORALIS = VERSION
 
 interface Window {
   WalletConnectProvider: any

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/node",
-  "version": "2.0.1",
+  "version": "2.0.1-rc.1",
   "type": "commonjs",
   "exports": {
     "module": "./build/index.module.js",
@@ -41,5 +41,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthNode"
+  "amdName": "UAuthNode",
+  "stableVersion": "2.0.1"
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "microbundle --target node",
     "dev": "microbundle watch --target node",
-    "release": "../../scripts/release.sh"
+    "release": "../../scripts/release.sh",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "dependencies": {
     "@types/express": "^4.17.13",

--- a/packages/web3-onboard/package.json
+++ b/packages/web3-onboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/web3-onboard",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -42,5 +42,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthWeb3Onboard"
+  "amdName": "UAuthWeb3Onboard",
+  "stableVersion": "2.0.0"
 }

--- a/packages/web3-onboard/package.json
+++ b/packages/web3-onboard/package.json
@@ -14,9 +14,10 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
-    "typecheck": "tsc --noEmit"
+    "build": "yarn export-version; microbundle",
+    "dev": "yarn export-version; microbundle watch",
+    "typecheck": "tsc --noEmit",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "dependencies": {
     "@uauth/js": "workspace:*"

--- a/packages/web3-onboard/src/index.ts
+++ b/packages/web3-onboard/src/index.ts
@@ -12,6 +12,11 @@ import {
   ProviderRpcError,
   ProviderRpcErrorCode,
 } from '@web3-onboard/common'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.WEB3_ONBOARD = VERSION
 
 export interface ConstructorOptions {
   uauth: UAuth

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -16,9 +16,10 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle --jsx 'React.createElement'",
-    "dev": "microbundle watch --jsx 'React.createElement'",
-    "release": "../../scripts/release.sh"
+    "build": "yarn export-version; microbundle --jsx 'React.createElement'",
+    "dev": "yarn export-version; microbundle watch --jsx 'React.createElement'",
+    "release": "../../scripts/release.sh",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "dependencies": {
     "@uauth/js": "workspace:*",

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/web3-react",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -29,5 +29,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthWeb3React"
+  "amdName": "UAuthWeb3React",
+  "stableVersion": "2.0.0"
 }

--- a/packages/web3-react/src/UAuthConnector.ts
+++ b/packages/web3-react/src/UAuthConnector.ts
@@ -10,6 +10,11 @@ import {
   ConnectorEvent,
   ConnectorUpdate,
 } from '@web3-react/types'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.WEB3_REACT = VERSION
 
 export interface UAuthConnectors {
   injected: AbstractConnector

--- a/packages/web3modal/package.json
+++ b/packages/web3modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/web3modal",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",
@@ -32,5 +32,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "amdName": "UAuthWeb3Modal"
+  "amdName": "UAuthWeb3Modal",
+  "stableVersion": "2.0.0"
 }

--- a/packages/web3modal/package.json
+++ b/packages/web3modal/package.json
@@ -16,9 +16,10 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
-    "release": "../../scripts/release.sh"
+    "build": "yarn export-version; microbundle",
+    "dev": "yarn export-version; microbundle watch",
+    "release": "../../scripts/release.sh",
+    "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },
   "devDependencies": {
     "@uauth/js": "workspace:*",

--- a/packages/web3modal/src/index.ts
+++ b/packages/web3modal/src/index.ts
@@ -5,6 +5,11 @@ import Web3Modal, {
   IAbstractConnectorOptions,
   IProviderDisplay,
 } from 'web3modal'
+import {VERSION} from './version'
+
+const _w = window as any
+_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+_w.UAUTH_VERSION.WEB3MODAL = VERSION
 
 export interface IUAuthOptions
   extends Partial<IAbstractConnectorOptions>,


### PR DESCRIPTION
We need a way to tell the version integrations. To solve this we'd like to attach the current version of the package to the window. This way our people can inspect webpages to tell the version of the integration.


<img width="1914" alt="Screen Shot 2022-07-19 at 6 01 26 AM" src="https://user-images.githubusercontent.com/107421942/179756468-a081ac03-a04d-4707-b7a2-d76a58082f0d.png">


I added `export-version` script in every package.json to generate the current package version export file.
Simply we can use `import {version} from 'package.json' but would bundle the whole package.json and thus expose the versions of dependencies and possibly other sensitive data too.

Please `import {version} from '../package.json` throwed some side-effect errors.

https://github.com/axelpale/genversion
