### PR TITLE
[LOG-349] Add package name and version tracking

### DIFF
--- a/packages/bnc-onboard/src/index.ts
+++ b/packages/bnc-onboard/src/index.ts
@@ -8,9 +8,11 @@ import type {IWalletConnectProviderOptions} from '@walletconnect/types'
 import type {API, WalletModule} from 'bnc-onboard/dist/src/interfaces'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.BNC_ONBOARD = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.BNC_ONBOARD = VERSION
+}
 
 export interface ConstructorOptions extends Partial<UAuthConstructorOptions> {
   uauth?: UAuth
@@ -126,7 +128,10 @@ export default class UAuthBNCOnboard {
           }
 
           if (this.options.shouldLoginWithRedirect) {
-            await this.uauth.login()
+            await this.uauth.login({
+              packageName: '@uauth/bnc-onboard',
+              packageVersion: VERSION,
+            })
 
             // NOTE: We don't want to throw because the page will take some time to
             // load the redirect page.
@@ -135,7 +140,10 @@ export default class UAuthBNCOnboard {
             // We need to throw here otherwise typescript won't know that user isn't null.
             throw new Error('Should never get here.')
           } else {
-            await this.uauth.loginWithPopup()
+            await this.uauth.loginWithPopup({
+              packageName: '@uauth/bnc-onboard',
+              packageVersion: VERSION,
+            })
             user = await this.uauth.user()
           }
         }

--- a/packages/common/src/DefaultWebFingerResolver.ts
+++ b/packages/common/src/DefaultWebFingerResolver.ts
@@ -2,9 +2,11 @@ import {isJRD} from './JRD'
 import {JRDDocument, WebFingerRecord, WebFingerResolverOptions} from './types'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.COMMON = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.COMMON = VERSION
+}
 
 export default class DefaultWebFingerResolver {
   constructor(public options: WebFingerResolverOptions) {}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -250,6 +250,10 @@ export interface AuthorizationEndpointRequest {
   // sessionToken: string
   state: string
 
+  // version tracking
+  package_name?: string
+  package_version?: string
+
   // Added for Index Signature
   [key: string]: any
 }

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -42,9 +42,11 @@ import {
 import * as util from './util'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.JS = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.JS = VERSION
+}
 
 export default class Client {
   util = util
@@ -212,6 +214,10 @@ export default class Client {
       // Constant options
       code_challenge_method: 'S256',
       response_type: 'code',
+
+      // package info
+      package_name: loginOptions?.packageName,
+      package_version: loginOptions?.packageVersion,
     }
 
     await this._clientStore.setAuthorizeRequest(request)

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -216,8 +216,8 @@ export default class Client {
       response_type: 'code',
 
       // package info
-      package_name: loginOptions?.packageName,
-      package_version: loginOptions?.packageVersion,
+      package_name: loginOptions?.packageName || '@uauth/js',
+      package_version: loginOptions?.packageVersion || VERSION,
     }
 
     await this._clientStore.setAuthorizeRequest(request)

--- a/packages/js/src/api/types.ts
+++ b/packages/js/src/api/types.ts
@@ -22,6 +22,8 @@ export interface AuthorizeRequest extends BaseRequest {
   response_mode: ResponseMode
   scope: string
   state: string
+  package_name?: string
+  package_version?: string
 }
 
 export interface AuthorizeWithJWTRequest {

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -207,6 +207,8 @@ export interface BaseLoginOptions {
   responseMode: ResponseMode
   scope: string
   flowId?: 'login' | 'signup'
+  packageName?: string
+  packageVersion?: string
 }
 
 export interface LoginOptions extends Partial<BaseLoginOptions> {

--- a/packages/moralis/src/UAuthMoralisConnector.ts
+++ b/packages/moralis/src/UAuthMoralisConnector.ts
@@ -7,9 +7,11 @@ import {getMoralisRpcs} from './MoralisRpcs'
 import verifyChainId from './Utils'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.MORALIS = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.MORALIS = VERSION
+}
 
 interface Window {
   WalletConnectProvider: any
@@ -84,7 +86,10 @@ class UAuthMoralisConnector extends AbstractWeb3Connector {
       }
 
       if (UAuthMoralisConnector.options.shouldLoginWithRedirect) {
-        await this.uauth.login()
+        await this.uauth.login({
+          packageName: '@uauth/moralis',
+          packageVersion: VERSION,
+        })
 
         // NOTE: We don't want to throw because the page will take some time to
         // load the redirect page.
@@ -93,7 +98,10 @@ class UAuthMoralisConnector extends AbstractWeb3Connector {
         // We need to throw here otherwise typescript won't know that user isn't null.
         throw new Error('Should never get here.')
       } else {
-        await this.uauth.loginWithPopup()
+        await this.uauth.loginWithPopup({
+          packageName: '@uauth/moralis',
+          packageVersion: VERSION,
+        })
         user = await this.uauth.user()
       }
     }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,8 +16,8 @@
     "build"
   ],
   "scripts": {
-    "build": "microbundle --target node",
-    "dev": "microbundle watch --target node",
+    "build": "yarn export-version; microbundle --target node",
+    "dev": "yarn export-version; microbundle watch --target node",
     "release": "../../scripts/release.sh",
     "export-version": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > ./src/version.ts"
   },

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -13,6 +13,7 @@ import {
 import type {Request, Response, NextFunction} from 'express'
 import {generateCodeChallengeAndVerifier, getRandomBytes} from './util'
 import verifyIdToken from './verifyIdToken'
+import {VERSION} from './version'
 
 interface Interaction {
   state: string
@@ -224,6 +225,8 @@ class Client {
       response_mode: 'form_post',
       scope: this.options.scope,
       prompt: 'login',
+      package_name: '@uauth/node',
+      package_version: VERSION,
     }
 
     const interaction: Interaction = {

--- a/packages/web3-onboard/src/index.ts
+++ b/packages/web3-onboard/src/index.ts
@@ -14,9 +14,11 @@ import {
 } from '@web3-onboard/common'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.WEB3_ONBOARD = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.WEB3_ONBOARD = VERSION
+}
 
 export interface ConstructorOptions {
   uauth: UAuth
@@ -50,7 +52,10 @@ export default function uauthBNCModule(
           }
 
           if (options.shouldLoginWithRedirect) {
-            await uauth.login()
+            await uauth.login({
+              packageName: '@uauth/web3-onboard',
+              packageVersion: VERSION,
+            })
 
             // NOTE: We don't want to throw because the page will take some time to
             // load the redirect page.
@@ -59,7 +64,10 @@ export default function uauthBNCModule(
             // We need to throw here otherwise typescript won't know that user isn't null.
             throw new Error('Should never get here.')
           } else {
-            await uauth.loginWithPopup()
+            await uauth.loginWithPopup({
+              packageName: '@uauth/web3-onboard',
+              packageVersion: VERSION,
+            })
             user = await uauth.user()
           }
         }

--- a/packages/web3-react/src/UAuthConnector.ts
+++ b/packages/web3-react/src/UAuthConnector.ts
@@ -12,9 +12,11 @@ import {
 } from '@web3-react/types'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.WEB3_REACT = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.WEB3_REACT = VERSION
+}
 
 export interface UAuthConnectors {
   injected: AbstractConnector
@@ -92,7 +94,10 @@ class UAuthConnector extends AbstractConnector {
       }
 
       if (this.options.shouldLoginWithRedirect) {
-        await this.uauth.login()
+        await this.uauth.login({
+          packageName: '@uauth/web3-react',
+          packageVersion: VERSION,
+        })
 
         // NOTE: We don't want to throw because the page will take some time to
         // load the redirect page.
@@ -101,7 +106,10 @@ class UAuthConnector extends AbstractConnector {
         // We need to throw here otherwise typescript won't know that user isn't null.
         throw new Error('Should never get here.')
       } else {
-        await this.uauth.loginWithPopup()
+        await this.uauth.loginWithPopup({
+          packageName: '@uauth/web3-react',
+          packageVersion: VERSION,
+        })
         user = await this.uauth.user()
       }
     }

--- a/packages/web3modal/src/index.ts
+++ b/packages/web3modal/src/index.ts
@@ -7,9 +7,11 @@ import Web3Modal, {
 } from 'web3modal'
 import {VERSION} from './version'
 
-const _w = window as any
-_w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
-_w.UAUTH_VERSION.WEB3MODAL = VERSION
+if (typeof window !== 'undefined') {
+  const _w = window as any
+  _w.UAUTH_VERSION = _w.UAUTH_VERSION || {}
+  _w.UAUTH_VERSION.WEB3MODAL = VERSION
+}
 
 export interface IUAuthOptions
   extends Partial<IAbstractConnectorOptions>,
@@ -50,7 +52,10 @@ export const connector = async (
     }
 
     if (opts.shouldLoginWithRedirect) {
-      await uauth.login()
+      await uauth.login({
+        packageName: '@uauth/web3modal',
+        packageVersion: VERSION,
+      })
 
       // NOTE: We don't want to throw because the page will take some time to
       // load the redirect page.
@@ -59,7 +64,10 @@ export const connector = async (
       // We need to throw here otherwise typescript won't know that user isn't null.
       throw new Error('Should never get here.')
     } else {
-      await uauth.loginWithPopup()
+      await uauth.loginWithPopup({
+        packageName: '@uauth/web3modal',
+        packageVersion: VERSION,
+      })
       user = await uauth.user()
     }
   }


### PR DESCRIPTION
### Problem
We want to track which package and version are integrated into a client.

### Solution
`packageName` and `packageVersion` are added in LoginOptions type that are used in UAauth.login and UAuth.loginWithPopup.
This package info will be passed to `buildAuthorizeRequest` and then `package_name` and `package_version` will be passed to `uauth-service` as query params.

### Screenshot
<img width="1817" alt="Screen Shot 2022-07-21 at 7 46 31 PM" src="https://user-images.githubusercontent.com/107421942/180352378-184c4c8d-a0fc-412b-95ca-6b552e303716.png">

