### PR TITLE
Update web3-react example with error handling

### DIFF
--- a/examples/spa/.gitignore
+++ b/examples/spa/.gitignore
@@ -19,5 +19,6 @@
 .env.production.local
 
 npm-debug.log*
+.yarn
 yarn-debug.log*
 yarn-error.log*

--- a/examples/web3-react/.gitignore
+++ b/examples/web3-react/.gitignore
@@ -19,5 +19,6 @@
 .env.production.local
 
 npm-debug.log*
+.yarn
 yarn-debug.log*
 yarn-error.log*

--- a/examples/web3-react/src/App.tsx
+++ b/examples/web3-react/src/App.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import connectors from './connectors'
 
 const App: React.FC = () => {
-  const {active, account, activate, deactivate} = useWeb3React()
+  const {active, account, error, activate, deactivate} = useWeb3React()
 
   function createConnectHandler(connectorId: string) {
     return async () => {
@@ -20,6 +20,9 @@ const App: React.FC = () => {
         }
 
         await activate(connector)
+        if (error) {
+          throw error;
+        }
       } catch (error) {
         console.error(error)
       }

--- a/examples/web3-react/src/connectors.ts
+++ b/examples/web3-react/src/connectors.ts
@@ -4,9 +4,13 @@ import {InjectedConnector} from '@web3-react/injected-connector'
 import {WalletConnectConnector} from '@web3-react/walletconnect-connector'
 
 // Instanciate your other connectors.
-export const injected = new InjectedConnector({supportedChainIds: [1]})
+const supportedChainIds = [1]
+export const injected = new InjectedConnector({
+  supportedChainIds: supportedChainIds,
+})
 
 export const walletconnect = new WalletConnectConnector({
+  supportedChainIds: supportedChainIds,
   infuraId: process.env.REACT_APP_INFURA_ID!,
   qrcode: true,
 })


### PR DESCRIPTION
The `activate()` method provided by the `useWeb3React()` hook does not throw errors in a way that can be handled with a standard try/catch. An additional `error` field is provided by the hook, which must be inspected after `activate()` returns. Any activation related errors will be present in the `error` field.

Updated the web3-react example to show how such an error can be handled.