### PR TITLE
feat: add some npm display info

### DIFF
--- a/packages/bnc-onboard/package.json
+++ b/packages/bnc-onboard/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@uauth/bnc-onboard",
   "version": "2.4.0",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/bnc-onboard#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/bnc-onboard"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@uauth/common",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/common#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/common"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "version": "2.3.0",
   "type": "module",
   "exports": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@uauth/js",
   "version": "2.4.0",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/js"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",

--- a/packages/moralis/package.json
+++ b/packages/moralis/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@uauth/moralis",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/moralis#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/moralis"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "version": "2.4.0",
   "type": "commonjs",
   "exports": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@uauth/node",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/node#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/node"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "version": "2.4.0",
   "type": "commonjs",
   "exports": {

--- a/packages/web3-onboard/package.json
+++ b/packages/web3-onboard/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@uauth/web3-onboard",
   "version": "2.4.0",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/web3-onboard#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/web3-onboard"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "type": "module",
   "exports": {
     "import": "./build/index.module.mjs",

--- a/packages/web3modal/package.json
+++ b/packages/web3modal/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@uauth/web3modal",
   "version": "2.4.0",
+  "homepage": "https://github.com/unstoppabledomains/uauth/tree/main/packages/web3modal#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unstoppabledomains/uauth.git",
+    "directory": "packages/web3modal"
+  },
+  "bugs": {
+    "url": "https://github.com/unstoppabledomains/uauth/issues"
+  },
   "main": "./build/index.js",
   "files": [
     "build"


### PR DESCRIPTION
add npm display info like homepage/issue/git link

the npm display info now has no related link shows:
<img width="1257" alt="image" src="https://user-images.githubusercontent.com/10740043/234803413-dc8ccc14-c024-4454-b092-50a1b33cbd4a.png">


expected as web3-react:
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/10740043/234803265-29f48e3d-258b-4866-8dd7-28791875b802.png">
