### PR TITLE
Prevent need for dynamic wagmi import

### DIFF
--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/wagmi",
-  "version": "2.10.0",
+  "version": "2.20.0",
   "files": [
     "build/*"
   ],

--- a/packages/wagmi/src/UAuthWagmiConnector.ts
+++ b/packages/wagmi/src/UAuthWagmiConnector.ts
@@ -5,10 +5,12 @@ import type {UserInfo} from '@uauth/js'
 import WalletConnectProvider from '@walletconnect/ethereum-provider'
 import {providers} from 'ethers'
 import {getAddress} from 'ethers/lib/utils.js'
-import {Chain, mainnet} from 'wagmi/chains'
+import type {Chain} from 'wagmi/chains'
 
 import {VERSION} from './version'
 import EventEmitter = require('eventemitter3')
+
+const MAINNET_ID = 1
 
 const normalizeChainId = (chainId: string | number | BigInt): number => {
   return Number(chainId)
@@ -254,7 +256,7 @@ class UAuthWagmiConnector<
     return subProvider
   }
 
-  async getSigner({chainId = mainnet.id} = {}): Promise<JsonRpcSigner> {
+  async getSigner({chainId = MAINNET_ID} = {}): Promise<JsonRpcSigner> {
     const [provider, account] = await Promise.all([
       this.getProvider(),
       this.getAccount(),


### PR DESCRIPTION
Removing import of wagmi mainnet chain, fixes dynamic import error.

Recreated error:

<img width="1146" alt="Screenshot 2023-08-09 at 8 49 07 PM" src="https://github.com/unstoppabledomains/uauth/assets/104389860/15636359-ecc9-4602-b1e4-f4d9e9480b9f">


