### PR TITLE
Bump NPM version for Ledger hotfix release

### DIFF
--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uauth/wagmi",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "files": [
     "build/*"
   ],


### PR DESCRIPTION
The previous PR patched the repo. This PR bumps the package version for NPM release.